### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ The ``metalchemy`` package provides helpers for your SQLAlchemy models to add dy
 
 .. image:: https://api.travis-ci.org/paylogic/metalchemy.png
    :target: https://travis-ci.org/paylogic/metalchemy
-.. image:: https://pypip.in/v/metalchemy/badge.png
+.. image:: https://img.shields.io/pypi/v/metalchemy.svg
    :target: https://crate.io/packages/metalchemy/
 .. image:: https://coveralls.io/repos/paylogic/metalchemy/badge.png?branch=master
    :target: https://coveralls.io/r/paylogic/metalchemy


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20metalchemy))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `metalchemy`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.